### PR TITLE
Add $args to posts markup

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -220,7 +220,7 @@ function rpwe_get_recent_posts( $args = array() ) {
 	do_action( 'rpwe_after_loop' );
 
 	// Return the  posts markup.
-	return wp_kses_post( $args['before'] ) . apply_filters( 'rpwe_markup', $html ) . wp_kses_post( $args['after'] );
+	return wp_kses_post( $args['before'] ) . apply_filters( 'rpwe_markup', $html, $args ) . wp_kses_post( $args['after'] );
 
 }
 


### PR DESCRIPTION
The current version does not pass any $args which makes the content blank. I added $args so that it can pass through the filter.